### PR TITLE
Begin draining a node when it enters `Terminating` state

### DIFF
--- a/pkg/trigger/aws/autoscaling/asg.go
+++ b/pkg/trigger/aws/autoscaling/asg.go
@@ -12,7 +12,10 @@ import (
 
 const (
 	// InstanceTerminatingStatus describes EC2 instance termination status
-	InstanceTerminatingStatus = "Terminating:Wait"
+	InstanceTerminatingStatus = "Terminating"
+
+	// InstanceTerminatingWaitStatus describes EC2 instance termination:wait status
+	InstanceTerminatingWaitStatus = "Terminating:Wait"
 
 	// LifecycleActionResultContinue describes ASG instance lifecycle continue result
 	LifecycleActionResultContinue = "CONTINUE"
@@ -98,4 +101,12 @@ func (a *AutoScaling) IsTerminating(status *string) bool {
 		return false
 	}
 	return *status == InstanceTerminatingStatus
+}
+
+// IsTerminatingWait returns true if the provided status is in terminating:wait state
+func (a *AutoScaling) IsTerminatingWait(status *string) bool {
+	if status == nil {
+		return false
+	}
+	return *status == InstanceTerminatingWaitStatus
 }


### PR DESCRIPTION
... and continue with other operations once it reaches
`Terminating:wait` state.

As per https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-conn-drain.html

> If your instances are part of an Auto Scaling group and connection draining
> is enabled for your load balancer, Auto Scaling waits for the in-flight
> requests to complete, or for the maximum timeout to expire, before
> terminating instances due to a scaling event or health check replacement

ASGs will beging draining nodes from load balancers while in
`Terminating` state, and will even remove them from the load balancer
before the node transitions to `Terminating:wait`. This means if you
depend on pod evictions to move a critical service to another available
node in the load balancer target group, this will only happen _after_
that node has already been drained and removed from the load balancer.

This effect is amplified whenever there is a timeout, or Deregistration delay
value set on the load balancer. The default value is 300 seconds, as per
here: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html#deregistration-delay

By draining sooner, critical pods providing service through that load
balancer can move to other nodes and maintain uptime while the node is
being deregistered from the load balancer.