### PR TITLE
Use zerolog for logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,3 @@ COPY --from=builder /user/group /user/passwd /etc/
 USER nobody:nobody
 
 ENTRYPOINT ["kubedrainer", "serve"]
-CMD ["-v1"]

--- a/cmd/kubedrainer/drain.go
+++ b/cmd/kubedrainer/drain.go
@@ -7,9 +7,9 @@ import (
 	"github.com/VirtusLab/kubedrainer/internal/stringer"
 	"github.com/VirtusLab/kubedrainer/pkg/drainer"
 	"github.com/VirtusLab/kubedrainer/pkg/kubernetes"
+	"github.com/rs/zerolog/log"
 
 	"github.com/VirtusLab/go-extended/pkg/errors"
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -48,7 +48,8 @@ func drainCmd() *cobra.Command {
 		Short: "Drain a node",
 		Long:  `Drain a node by cordoning and pod eviction`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			glog.Info("Running locally")
+			setupLogging()
+			log.Info().Msg("Running locally")
 
 			if err := options.Parse(cmd); err != nil {
 				return err
@@ -83,14 +84,14 @@ func (f *DrainFlags) AddTo(flags *pflag.FlagSet) {
 func (o *DrainOptions) Parse(cmd *cobra.Command) error {
 	settings.Bind(cmd.Flags()) // needs to be run inside the command and before any viper usage for flags to be visible
 
-	glog.V(4).Infof("All keys: %+v", viper.AllKeys())
-	glog.V(2).Infof("All settings: %+v", viper.AllSettings())
-	if glog.V(4) {
+	if debug {
+		log.Debug().Msgf("All keys: %+v", viper.AllKeys())
+		log.Debug().Msgf("All settings: %+v", viper.AllSettings())
 		cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-			glog.Infof("'%s' -> flag: '%+v' | setting: '%+v'", flag.Name, flag.Value, viper.Get(flag.Name))
+			log.Debug().Msgf("'%s' -> flag: '%+v' | setting: '%+v'", flag.Name, flag.Value, viper.Get(flag.Name))
 		})
+		log.Debug().Msgf("Settings: %+v", *o)
 	}
-	glog.V(1).Infof("Settings: %+v", *o)
 
 	if err := settings.Parse(o.Kubernetes); err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,17 @@ require (
 	github.com/VirtusLab/go-extended v0.0.11
 	github.com/aws/aws-sdk-go v1.34.3
 	github.com/fsnotify/fsnotify v1.4.9
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3
+	github.com/rs/zerolog v1.19.0
+	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
+	github.com/stretchr/testify v1.6.1 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c // indirect
 	k8s.io/api v0.17.9
 	k8s.io/apimachinery v0.17.9
 	k8s.io/cli-runtime v0.17.9

--- a/go.sum
+++ b/go.sum
@@ -213,6 +213,8 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
+github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
@@ -293,6 +295,9 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
+github.com/rs/zerolog v1.19.0 h1:hYz4ZVdUgjXTBUmrkrw55j1nHx68LfOKIQk5IYtyScg=
+github.com/rs/zerolog v1.19.0/go.mod h1:IzD0RJ65iWH0w97OQQebJEvTZYvsCUm9WVLWBQrJRjo=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
@@ -304,6 +309,8 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/assertions v1.0.0 h1:UVQPSSmc3qtTi+zPPkCXvZX9VvW/xT/NsRvKfwY81a8=
+github.com/smartystreets/assertions v1.0.0/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
@@ -339,6 +346,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -468,6 +477,7 @@ golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -507,6 +517,8 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
@@ -524,6 +536,9 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c h1:grhR+C34yXImVGp7EzNk+DTIk+323eIUWOmEevy6bDo=
+gopkg.in/yaml.v3 v3.0.0-20200605160147-a5ece683394c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/stringer/stringify.go
+++ b/internal/stringer/stringify.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/golang/glog"
+	"github.com/rs/zerolog/log"
 )
 
 // Stringify converts a given interface into a human readable string
@@ -35,9 +35,7 @@ func Stringify(v interface{}) string {
 		}
 		return fmt.Sprintf("{%+v}", strings.Join(values, " "))
 	case reflect.Invalid:
-		if glog.V(5) {
-			glog.Infof("invalid value: %s %s %s", reflect.TypeOf(v), reflect.ValueOf(v).Type().Kind(), value.Kind())
-		}
+		log.Debug().Msgf("invalid value: %s %s %s", reflect.TypeOf(v), reflect.ValueOf(v).Type().Kind(), value.Kind())
 		return "?"
 	default:
 		return fmt.Sprintf("%+v", v)

--- a/pkg/drainer/drainer.go
+++ b/pkg/drainer/drainer.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/VirtusLab/kubedrainer/internal/stringer"
 	"github.com/VirtusLab/kubedrainer/pkg/kubernetes/node"
+	"github.com/rs/zerolog/log"
 
 	"github.com/VirtusLab/go-extended/pkg/errors"
-	"github.com/golang/glog"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,19 +45,19 @@ func (o *Options) String() string {
 	return stringer.Stringify(o)
 }
 
-// ErrWriter allows for Glog usage inside kubectl drainer implementation
+// ErrWriter allows for log usage inside kubectl drainer implementation
 type ErrWriter struct{}
 
-// OutWriter allows for Glog usage inside kubectl drainer implementation
+// OutWriter allows for log usage inside kubectl drainer implementation
 type OutWriter struct{}
 
 func (ErrWriter) Write(p []byte) (n int, err error) {
-	glog.Error(string(p))
+	log.Error().Msg(string(p))
 	return len(p), nil
 }
 
 func (OutWriter) Write(p []byte) (n int, err error) {
-	glog.Info(string(p))
+	log.Info().Msg(string(p))
 	return len(p), nil
 }
 
@@ -91,7 +91,7 @@ func New(client kubernetes.Interface, options *Options) Drainer {
 }
 
 func (o *drainCmdOptions) Drain(nodeName string) error {
-	glog.Infof("Draining node: '%s'", nodeName)
+	log.Info().Msgf("Draining node: '%s'", nodeName)
 	if len(nodeName) == 0 {
 		return errors.New("node name cannot be empty")
 	}

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -4,7 +4,7 @@ import (
 	"github.com/VirtusLab/kubedrainer/internal/stringer"
 
 	"github.com/VirtusLab/go-extended/pkg/errors"
-	"github.com/golang/glog"
+	"github.com/rs/zerolog/log"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
 )
@@ -30,26 +30,21 @@ func New(options *Options) (*Client, error) {
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
-	if glog.V(2) {
-		glog.Infof("Context: %s", *options.Context)
-	}
-	if glog.V(4) {
-		glog.Infof("Configured Host: %s", clientConfig.Host)
-		glog.Infof("Configured AuthProvider: %s", clientConfig.AuthProvider)
-		glog.Infof("Configured ExecProvider: %s", clientConfig.ExecProvider)
-	}
+	log.Debug().Msgf("Context: %s", *options.Context)
+	log.Debug().Msgf("Configured Host: %s", clientConfig.Host)
+	log.Debug().Msgf("Configured AuthProvider: %s", clientConfig.AuthProvider)
+	log.Debug().Msgf("Configured ExecProvider: %s", clientConfig.ExecProvider)
 
 	client, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
 		return nil, errors.Wrap(err)
 	}
-	if glog.V(1) {
-		version, err := client.ServerVersion()
-		if err != nil {
-			return nil, errors.Wrap(err)
-		}
-		glog.Infof("Server version: %s", version.String())
+
+	version, err := client.ServerVersion()
+	if err != nil {
+		return nil, errors.Wrap(err)
 	}
+	log.Debug().Msgf("Server version: %s", version.String())
 
 	return client, err
 }

--- a/pkg/kubernetes/node/node.go
+++ b/pkg/kubernetes/node/node.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/VirtusLab/go-extended/pkg/errors"
 	"github.com/VirtusLab/go-extended/pkg/matcher"
-	"github.com/golang/glog"
+	"github.com/rs/zerolog/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -31,7 +31,7 @@ func (n *Node) GetNode(nodeName string) (*corev1.Node, error) {
 	}
 	for _, n := range nodes.Items {
 		if n.Name == nodeName {
-			glog.V(1).Infof("Found node: '%s'", nodeName)
+			log.Debug().Msgf("Found node: '%s'", nodeName)
 			return &n, nil
 		}
 	}


### PR DESCRIPTION
Closes #6

This will switch the default logging format to JSON. For simplicity, it
will also change from multiple `v` arguments for increased verbosity to
a single `-d` or `--debug` flag. A side effect of this is that `-v` can
again be used for version. It seems it was being overloaded previously.