### PR TITLE
Fix instance data expression

### DIFF
--- a/cmd/kubedrainer/serve.go
+++ b/cmd/kubedrainer/serve.go
@@ -201,7 +201,7 @@ func GetNodeInformation(nodeName string, kubernetesClient k8s.Interface) (string
 	}
 	switch providerName {
 	case "aws":
-		awsNodeIDExpression := `^/(?P<Region>[a-zA-Z0-9-]+)[a-z]/(?P<InstanceID>[a-zA-Z0-9-]+)$`
+		awsNodeIDExpression := `^/?(?P<Region>[a-zA-Z0-9-]+)[a-z]/(?P<InstanceID>[a-zA-Z0-9-]+)$`
 		results, ok := matcher.Must(awsNodeIDExpression).MatchGroups(providerSpecificNodeID)
 		if !ok {
 			return "", "", errors.Errorf("Can't match expression '%s' to '%s'",


### PR DESCRIPTION
Fixes: https://github.com/VirtusLab/kubedrainer/issues/9

```
│ {"level":"warn","time":1610568409,"message":"No config file found"}                                                                                                                                                                                        │
│ {"level":"info","time":1610568409,"message":"Running as server"}                                                                                                                                                                                           │
│ {"level":"debug","time":1610568409,"message":"All keys: [timeout region force instance-id ignore-daemonsets help user request-timeout certificate-authority pod-selector server cache-dir client-certificate debug context client-key cluster delete-local │
│ {"level":"debug","time":1610568409,"message":"All settings: map[cache-dir:/.kube/http-cache certificate-authority: client-certificate: client-key: cluster: config: context: debug:true delete-local-data:true force:false grace-period:-1 help:false igno │
│ {"level":"debug","time":1610568409,"message":"'cache-dir' -> flag: '/.kube/http-cache' | setting: '/.kube/http-cache'"}                                                                                                                                    │
│ {"level":"debug","time":1610568409,"message":"'certificate-authority' -> flag: '' | setting: ''"}                                                                                                                                                          │
│ {"level":"debug","time":1610568409,"message":"'client-certificate' -> flag: '' | setting: ''"}                                                                                                                                                             │
│ {"level":"debug","time":1610568409,"message":"'client-key' -> flag: '' | setting: ''"}                                                                                                                                                                     │
│ {"level":"debug","time":1610568409,"message":"'cluster' -> flag: '' | setting: ''"}                                                                                                                                                                        │
│ {"level":"debug","time":1610568409,"message":"'config' -> flag: '' | setting: ''"}                                                                                                                                                                         │
│ {"level":"debug","time":1610568409,"message":"'context' -> flag: '' | setting: ''"}                                                                                                                                                                        │
│ {"level":"debug","time":1610568409,"message":"'debug' -> flag: 'true' | setting: 'true'"}                                                                                                                                                                  │
│ {"level":"debug","time":1610568409,"message":"'delete-local-data' -> flag: 'true' | setting: 'true'"}                                                                                                                                                      │
│ {"level":"debug","time":1610568409,"message":"'force' -> flag: 'false' | setting: 'false'"}                                                                                                                                                                │
│ {"level":"debug","time":1610568409,"message":"'grace-period' -> flag: '-1' | setting: '-1'"}                                                                                                                                                               │
│ {"level":"debug","time":1610568409,"message":"'help' -> flag: 'false' | setting: 'false'"}                                                                                                                                                                 │
│ {"level":"debug","time":1610568409,"message":"'ignore-daemonsets' -> flag: 'true' | setting: 'true'"}                                                                                                                                                      │
│ {"level":"debug","time":1610568409,"message":"'insecure-skip-tls-verify' -> flag: 'false' | setting: 'false'"}                                                                                                                                             │
│ {"level":"debug","time":1610568409,"message":"'instance-id' -> flag: '' | setting: ''"}                                                                                                                                                                    │
│ {"level":"debug","time":1610568409,"message":"'kubeconfig' -> flag: '' | setting: ''"}                                                                                                                                                                     │
│ {"level":"debug","time":1610568409,"message":"'node' -> flag: '' | setting: 'ip-172-30-0-111.us-west-2.compute.internal'"}                                                                                                                                 │
│ {"level":"debug","time":1610568409,"message":"'pod-selector' -> flag: '' | setting: ''"}                                                                                                                                                                   │
│ {"level":"debug","time":1610568409,"message":"'profile' -> flag: '' | setting: ''"}                                                                                                                                                                        │
│ {"level":"debug","time":1610568409,"message":"'region' -> flag: '' | setting: ''"}                                                                                                                                                                         │
│ {"level":"debug","time":1610568409,"message":"'request-timeout' -> flag: '0' | setting: '0'"}                                                                                                                                                              │
│ {"level":"debug","time":1610568409,"message":"'selector' -> flag: '' | setting: ''"}                                                                                                                                                                       │
│ {"level":"debug","time":1610568409,"message":"'server' -> flag: '' | setting: ''"}                                                                                                                                                                         │
│ {"level":"debug","time":1610568409,"message":"'timeout' -> flag: '1m0s' | setting: '1m0s'"}                                                                                                                                                                │
│ {"level":"debug","time":1610568409,"message":"'token' -> flag: '' | setting: ''"}                                                                                                                                                                          │
│ {"level":"debug","time":1610568409,"message":"'user' -> flag: '' | setting: ''"}                                                                                                                                                                           │
│ {"level":"debug","time":1610568409,"message":"Settings: {Kubernetes:{ConfigFlags:{CacheDir:/.kube/http-cache KubeConfig: ClusterName: AuthInfoName: Context: Namespace:<nil> APIServer: Insecure:false CertFile: KeyFile: CAFile: BearerToken: Impersonate │
│ {"level":"debug","time":1610568409,"message":"Context: "}                                                                                                                                                                                                  │
│ {"level":"debug","time":1610568409,"message":"Configured Host: https://172.28.252.1:443"}                                                                                                                                                                  │
│ {"level":"debug","time":1610568409,"message":"Configured AuthProvider: <nil>"}                                                                                                                                                                             │
│ {"level":"debug","time":1610568409,"message":"Configured ExecProvider: <nil>"}                                                                                                                                                                             │
│ {"level":"debug","time":1610568410,"message":"Server version: v1.18.8"}                                                                                                                                                                                    │
│ {"level":"debug","time":1610568410,"message":"Getting node information"}                                                                                                                                                                                   │
│ {"level":"debug","time":1610568410,"message":"Using default AWS API credentials profile"}                                                                                                                                                                  │
│ {"level":"info","time":1610568410,"message":"Running node drainer on node 'ip-172-30-0-111.us-west-2.compute.internal' on instance 'i-001d9c66ac115fed9' in region 'us-west-2' and profile 'default'"}                                                     │
│ {"level":"info","time":1610568410,"message":"Sleeping 10s seconds"}                                                                                                                                                                                        │
```