### PR TITLE
Add drain-delay flag to wait before eviction

### DIFF
--- a/cmd/kubedrainer/main.go
+++ b/cmd/kubedrainer/main.go
@@ -112,6 +112,7 @@ func drainerFlags(options *drainer.Options) *pflag.FlagSet {
 	flags.Duration("timeout", options.Timeout, "The length of time to wait before giving up, zero means infinite")
 	flags.StringP("selector", "l", options.Selector, "Selector (label query) to filter on")
 	flags.StringP("pod-selector", "", options.PodSelector, "Label selector to filter pods on the node")
+	flags.String("drain-delay", options.DrainDelay.String(), "For how long to wait before draining a node")
 	return flags
 }
 

--- a/cmd/kubedrainer/serve.go
+++ b/cmd/kubedrainer/serve.go
@@ -45,6 +45,7 @@ func serveCmd() *cobra.Command {
 			Timeout:             60 * time.Second,
 			DeleteLocalData:     true,
 			IgnoreAllDaemonSets: true,
+			DrainDelay:          0 * time.Second,
 		},
 		AWS: &autoscaling.Options{
 			LoopSleepTime: 10 * time.Second,


### PR DESCRIPTION
This flag allows to specify a period of time for which drainer should
wait after cordoning a node. This ensure that for example after instance
refresh in EKS pods don't become 'Pending' for some period of time waiting for
the new node to come up.