### PR TITLE
Add missing mapstructure tags to drainer and asg options 

### DIFF
--- a/cmd/kubedrainer/drain.go
+++ b/cmd/kubedrainer/drain.go
@@ -99,6 +99,7 @@ func (o *DrainOptions) Parse(cmd *cobra.Command) error {
 	if err := settings.Parse(o.Drainer); err != nil {
 		return err
 	}
+	log.Debug().Msgf("Parsed settings: %+v", *o)
 	return nil
 }
 

--- a/pkg/drainer/drainer.go
+++ b/pkg/drainer/drainer.go
@@ -33,12 +33,12 @@ type Drainer interface {
 type Options struct {
 	Node                string
 	Force               bool
-	GracePeriodSeconds  int
-	IgnoreAllDaemonSets bool
+	GracePeriodSeconds  int  `mapstructure:"grace-period"`
+	IgnoreAllDaemonSets bool `mapstructure:"ignore-daemonsets"`
 	Timeout             time.Duration
-	DeleteLocalData     bool
+	DeleteLocalData     bool `mapstructure:"delete-local-data"`
 	Selector            string
-	PodSelector         string
+	PodSelector         string        `mapstructure:"pod-selector"`
 	DrainDelay          time.Duration `mapstructure:"drain-delay"`
 }
 

--- a/pkg/trigger/aws/autoscaling/asg.go
+++ b/pkg/trigger/aws/autoscaling/asg.go
@@ -30,11 +30,11 @@ type AutoScaling struct {
 
 // Options for AutoScaling
 type Options struct {
-	InstanceID     string
+	InstanceID     string `mapstructure:"instance-id"`
 	Region         string
 	Profile        string
-	LoopSleepTime  time.Duration
-	ShutdownSleep  time.Duration
+	LoopSleepTime  time.Duration `mapstructure:"loop-sleep-time"`
+	ShutdownSleep  time.Duration `mapstructure:"shutdown-sleep"`
 	ForceLoopBreak bool
 }
 


### PR DESCRIPTION
Per our discussion in #13 about some of the flags not working. [Link to the discussion](https://github.com/VirtusLab/kubedrainer/pull/13#discussion_r576625719).

This PR ensures that flags containing dashes are properly parsed by viper(mapstructure).


P.S. Sorry I had to postpone it a bit. I was pretty busy at work 🧑‍💼 💻 . 